### PR TITLE
Formatter conflicts

### DIFF
--- a/{{ cookiecutter.project_slug }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.project_slug }}/.devcontainer/devcontainer.json
@@ -22,16 +22,10 @@
                     "source.organizeImports": true
                 },
                 "isort.args": [
-                    "--profile", "black",
-                    "--line_length", "80",
-                    "--multi_line_output", "3",
-                    "--include_trailing_comma", "true",
-                    "force_grid_wrap", "0",
-                    "--use_parentheses", "true"
+                    "--settings-path", "${workspaceFolder}/setup.cfg"
                 ],
                 "flake8.args": [
-                    "--max-line-length", "80",
-                    "--extend-ignore", "E203"    
+                    "--config", "${workspaceFolder}/setup.cfg"
                 ]
             },
             "extensions": [

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         args: ['--maxkb=25000']
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.11.0
     hooks:
       - id: black
         args: ["--line-length=80"]
@@ -26,7 +26,7 @@ repos:
         args: ["--settings-path=setup.cfg"]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.1
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -23,13 +23,16 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
+        args: ["--settings-path=setup.cfg"]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]
-        additional_dependencies: [flake8-isort]
+        additional_dependencies: 
+          - flake8-isort
+          - flake8-bugbear~=23.11
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
 ci:

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         args: ["--settings-path=setup.cfg"]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.1
+    rev: 6.1.0
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
       - id: end-of-file-fixer
         types: [python]         
       - id: check-yaml
+      - id: check-added-large-files
+        args: ['--maxkb=25000']
 
   - repo: https://github.com/psf/black
     rev: 22.3.0

--- a/{{ cookiecutter.project_slug }}/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.txt
@@ -1,5 +1,6 @@
 # development tools
 flake8~=4.0
+flake8-bugbear~=23.11
 black~=22.1
 pre-commit~=2.20
 ipykernel~=6.16

--- a/{{ cookiecutter.project_slug }}/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.txt
@@ -1,8 +1,8 @@
 # development tools
-flake8~=4.0
+flake8~=6.1
 flake8-bugbear~=23.11
-black~=22.1
-pre-commit~=2.20
+black~=22.11
+pre-commit~=3.5
 ipykernel~=6.16
 
 # project packages

--- a/{{ cookiecutter.project_slug }}/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.txt
@@ -1,7 +1,7 @@
 # development tools
 flake8~=6.1
 flake8-bugbear~=23.11
-black~=22.11
+black~=23.11
 pre-commit~=3.5
 ipykernel~=6.16
 

--- a/{{ cookiecutter.project_slug }}/setup.cfg
+++ b/{{ cookiecutter.project_slug }}/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
+max-line-length = 88
 exclude = .tox,.git,*/migrations/*,docs,node_modules,venv,data
-extend-ignore = E203,E501
+extend-ignore = E203
 
 [isort]
 known_first_party = {{ cookiecutter.code_directory }}

--- a/{{ cookiecutter.project_slug }}/setup.cfg
+++ b/{{ cookiecutter.project_slug }}/setup.cfg
@@ -3,7 +3,6 @@ exclude = .tox,.git,*/migrations/*,docs,node_modules,venv,data
 extend-ignore = E203,E501
 
 [isort]
-line_length = 80
 known_first_party = {{ cookiecutter.code_directory }}
 profile = black
 default_section = THIRDPARTY

--- a/{{ cookiecutter.project_slug }}/setup.cfg
+++ b/{{ cookiecutter.project_slug }}/setup.cfg
@@ -3,14 +3,10 @@ max-line-length =
     # B950 allows this to be exceeded by 10%, matching black
     80
 exclude = .tox,.git,*/migrations/*,docs,node_modules,venv,data
-select = 
+extend-select = 
     # C,E,F,W,B,B950 recommended by black for use with flake8
     # https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#flake8
-    C,
-    E,
-    F,
-    W,
-    B,
+    # C,E,F,W selected by default.
     # B950: allows violations of line length up to 10%, ignores urls alone
     # on a line. closing parenthesis are not counted.
     B950

--- a/{{ cookiecutter.project_slug }}/setup.cfg
+++ b/{{ cookiecutter.project_slug }}/setup.cfg
@@ -1,7 +1,25 @@
 [flake8]
-max-line-length = 88
+max-line-length = 
+    # B950 allows this to be exceeded by 10%, matching black
+    80
 exclude = .tox,.git,*/migrations/*,docs,node_modules,venv,data
-extend-ignore = E203
+select = 
+    # C,E,F,W,B,B950 recommended by black for use with flake8
+    # https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#flake8
+    C,
+    E,
+    F,
+    W,
+    B,
+    # B950: allows violations of line length up to 10%, ignores urls alone
+    # on a line. closing parenthesis are not counted.
+    B950
+extend-ignore = 
+    # E203, E501, E704 all recommended for compatibility with black
+    E203,
+    # E501: line too long. Ignored because B950 implements this to avoid duplicates
+    E501,
+    E704
 
 [isort]
 known_first_party = {{ cookiecutter.code_directory }}


### PR DESCRIPTION
- Closes #21
- Closes #6 
- Updates solution to compatibility issue from #17 which I believe will allow some long lines that black ignores to be unflagged. This follows [black's recommended approach](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#flake8) which also gives some nice behaviors (ignores urls that break line length, doesn't count closing parenthesis)
- Updates versions of linters